### PR TITLE
Updated name of Firestore pod.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -84,7 +84,7 @@
       </feature>
     </config-file>
 
-    <framework src="FirebaseFirestore" type="podspec" spec="~> 0.10.2"/>
+    <framework src="Firebase/Firestore" type="podspec"/>
 
     <header-file src="src/ios/FirestorePlugin.h"/>
     <source-file src="src/ios/FirestorePlugin.m"/>


### PR DESCRIPTION
I was attempting to use your plugin and everything worked well in Android.  I attempted to build for iOS and I was getting a message in Xcode that the Firestore library was not found.  It looks like the pod that was being requested was incorrect.  I don't know if it has been renamed or something, but this name and using the most current version worked for me.