### PR TITLE
fix: example error with empty config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ var options = {
   "datePrefix": '__DATE:',
   "fieldValueDelete": "__DELETE",
   "fieldValueServerTimestamp" : "__SERVERTIMESTAMP",
-  "persist": true,
-  "config" : {}
+  "persist": true
+  // Use config to add custom app configuration, don't use empty config
+  // "config": {}
 };
 
 if (cordova.platformId === "browser") {


### PR DESCRIPTION
Fixes: #28 

I spent few hours to understand where my bug, and I think many people who want use this plugin intersects with this problem.
remove config key from initialization, because if we use this key with empty, calling firestore throwing errors.

Fixes #

Android
![image](https://user-images.githubusercontent.com/11452353/94800370-27839780-03ed-11eb-834a-ab8216f12c86.png)

IOS
![image](https://user-images.githubusercontent.com/11452353/94800563-716c7d80-03ed-11eb-860d-f1d66b11ad6c.png)


What I think? 
I think may be add same additional checking appid  in config object for android as in IOS code.=
## Proposed Changes

  - Fix example usage