### PR TITLE
FIX - Incorrect calculation of length of substring to get the date value

### DIFF
--- a/src/android/uk/co/reallysmall/cordova/plugin/firestore/JSONDateWrapper.java
+++ b/src/android/uk/co/reallysmall/cordova/plugin/firestore/JSONDateWrapper.java
@@ -29,7 +29,7 @@ public class JSONDateWrapper extends Date {
     public static Date unwrapDate(Object value) {
         String stringValue = (String) value;
         int prefixLength = datePrefix.length();
-        String timestamp = stringValue.substring(prefixLength + 1);
+        String timestamp = stringValue.substring(prefixLength);
 
         return new Date(Long.parseLong(timestamp));
     }


### PR DESCRIPTION
Fixes #37

## Proposed Changes

  - In `JSONDateWrapper.unwrapDate()`, change substring(prefixLength)